### PR TITLE
Support optional collapse parameters

### DIFF
--- a/src/main/kotlin/com/careem/gradle/dependencies/main.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/main.kt
@@ -11,18 +11,41 @@ import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
   val help = "-h" in args || "--help" in args
-  if (help || args.size != 2) {
+  if (help || args.size < 2) {
     System.err.println("Usage: dependency-tree-tldr old.txt new.txt")
+    System.err.println("  You can also pass in one or more optional --collapse arguments.")
+    System.err.println("  Note that these will only collapse if all version numbers match.")
+    System.err.println("  (ex --collapse com.careem.ridehail --collapse com.careem.now)")
     if (!help) {
       exitProcess(1)
     }
     return
   }
 
-  val old = Paths.get(args[0]).readText()
-  val new = Paths.get(args[1]).readText()
+  val files = arrayOf("", "")
+  val collapse = mutableListOf<String>()
 
-  print(tldr(old, new))
+  var filesIndex = 0
+  var isNextCollapse = false
+  args.forEachIndexed { index, _ ->
+    when {
+      isNextCollapse -> {
+        collapse.add(args[index])
+        isNextCollapse = false
+      }
+      "--collapse" == args[index] -> {
+        isNextCollapse = true
+      }
+      else -> {
+        files[filesIndex++] = args[index]
+      }
+    }
+  }
+
+  val old = Paths.get(files[0]).readText()
+  val new = Paths.get(files[1]).readText()
+
+  print(tldr(old, new, collapse))
 }
 
 private fun Path.readText(charset: Charset = StandardCharsets.UTF_8): String {


### PR DESCRIPTION
This patch supports optional collapse parameters, which will collapse
multiple upgraded artifacts that match the given prefix.

Note that this will only collapse:
- upgraded artifacts (not added or removed artifacts)
- only if all version numbers match
