### PR TITLE
Implement an option for showing side effects

### DIFF
--- a/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
@@ -1,0 +1,102 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.careem.gradle.dependencies
+
+import com.careem.gradle.dependencies.parser.Dependency
+import com.careem.gradle.dependencies.parser.parseDependencyTree
+
+fun upgradeEffects(old: String, new: String, collapseKeys: List<String>): String {
+    val (_, _, upgrades) = dependencyDifferences(old, new)
+    return if (upgrades.isNotEmpty()) {
+        val tree = parseDependencyTree(new)
+        val sideEffects = upgrades
+            .map { updatedDependency ->
+                // these are the dependencies that were transparently upgraded due to this upgrade
+                updatedDependency to tree.mapNotNull { treeDependency ->
+                    treeDependency.filterMatches {
+                        it.matches(updatedDependency.artifact) &&
+                                it.requestedVersion != it.resolvedVersion
+                    }
+                }
+            }
+            .map { it.first to it.second.map { dep -> dep.filterMatches { match -> match.group != "project" } ?: dep } }
+            .filter { it.second.isNotEmpty() }
+
+        // side effects are grouped by the dependency that was upgraded
+        // collapse dependencies with the same group with each other
+        // so that the output is more readable
+        val collapsedSideEffects = sideEffects
+            .groupBy { it.first.group }
+            .flatMap { (group, effects) ->
+                if (group in collapseKeys) {
+                    val upgradedDependency = effects.first().first
+                    val groupedUpgradedDependency = upgradedDependency.copy(artifact = "$group:*")
+                    effects.distinctBy { it.second }
+                        .map { dep ->
+                            val count = effects.count { it.second == dep.second }
+                            if (count > 1) {
+                                dep.copy(first = groupedUpgradedDependency)
+                            } else {
+                                dep
+                            }
+                        }
+                } else {
+                    effects
+                }
+            }
+
+        buildString {
+            collapsedSideEffects
+                .forEachIndexed { index, effects ->
+                    if (index > 0) {
+                        appendLine()
+                    }
+                    append("Changing ${effects.first.artifact} to ${effects.first.version} will also change:")
+                    effects.second
+                        .forEach { affectedDependency -> writeTree(affectedDependency, 1) }
+                    appendLine()
+                }
+        }
+    } else {
+        ""
+    }
+}
+
+private fun Dependency.matches(target: String) = artifact == target
+
+private fun Dependency.filterMatches(lambda: (Dependency) -> Boolean): Dependency? {
+    return if (lambda(this)) {
+        this.copy(children = emptyList())
+    } else {
+        val children = this.children.mapNotNull { it.filterMatches(lambda) }
+        if (children.isNotEmpty()) {
+            this.copy(children = children)
+        } else {
+            null
+        }
+    }
+}
+
+private fun StringBuilder.writeTree(dependency: Dependency, indent: Int) {
+    appendLine()
+    append(" ".repeat(indent * 4))
+    append(dependency.artifact)
+    append(" (")
+    append(dependency.resolvedVersion)
+    append(")")
+    dependency.children.forEach { writeTree(it, indent + 1) }
+}

--- a/src/main/kotlin/com/careem/gradle/dependencies/main.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/main.kt
@@ -27,6 +27,8 @@ import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
   val help = "-h" in args || "--help" in args
+  val sideEffects = "-s" in args || "--side-effects" in args
+
   if (help || args.size < 2) {
     System.err.println("Usage: dependency-tree-tldr old.txt new.txt")
     System.err.println("  You can also pass in one or more optional --collapse arguments.")
@@ -52,6 +54,9 @@ fun main(args: Array<String>) {
       "--collapse" == args[index] -> {
         isNextCollapse = true
       }
+      "--side-effects" == args[index] || "-s" == args[index] -> {
+        // do nothing
+      }
       else -> {
         files[filesIndex++] = args[index]
       }
@@ -62,6 +67,14 @@ fun main(args: Array<String>) {
   val new = Paths.get(files[1]).readText()
 
   print(tldr(old, new, collapse))
+  if (sideEffects) {
+    val upgradeEffects = upgradeEffects(old, new, collapse)
+    if (upgradeEffects.isNotEmpty()) {
+      println()
+      println("Upgrade Side Effects")
+      print(upgradeEffects)
+    }
+  }
 }
 
 private fun Path.readText(charset: Charset = StandardCharsets.UTF_8): String {

--- a/src/main/kotlin/com/careem/gradle/dependencies/parser/treeParser.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/parser/treeParser.kt
@@ -1,0 +1,115 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.careem.gradle.dependencies.parser
+
+data class Dependency(
+    val group: String,
+    val name: String,
+    val resolvedVersion: String,
+    val requestedVersion: String,
+    val children: List<Dependency> = emptyList()
+) {
+    val artifact: String = "$group:$name"
+}
+
+fun parseDependencyTree(dependenciesFile: String): List<Dependency> {
+    val dependencyLines = dependenciesFile.split("\n")
+        .dropWhile { !it.startsWith("+--- ") }
+        .takeWhile { it.isNotEmpty() }
+    return parseDependenciesForIndent(dependencyLines, 1)
+}
+
+private fun parseDependenciesForIndent(dependencyLines: List<String>, indent: Int): List<Dependency> {
+    val linesForIndent = dependencyLines
+        .takeWhile { it.indexOf("--- ") >= indent }
+        // remove dependency constraints, since they're not actual dependencies
+        .filter { "(c)" !in it }
+
+    return linesForIndent
+        .mapIndexedNotNull { index, dependencyLine ->
+            val artifactStart = dependencyLine.indexOf("--- ")
+            if (artifactStart == indent) {
+                parseDependency(dependencyLine, linesForIndent.safeSublistFrom(index + 1))
+            } else {
+                null
+            }
+        }
+}
+
+private fun parseDependency(dependencyLine: String, dependencyLines: List<String>): Dependency {
+    val dependency = parseDependency(dependencyLine)
+    val indent = dependencyLine.indexOf("--- ")
+    val nextIndent = dependencyLines.firstOrNull()?.indexOf("--- ") ?: -1
+
+    return if (indent < nextIndent) {
+        // this dependency has sub-dependencies
+        val children = parseDependenciesForIndent(dependencyLines, nextIndent)
+        dependency.copy(children = children)
+    } else {
+        // leaf dependency
+        dependency
+    }
+}
+
+private fun parseDependency(dependencyLine: String): Dependency {
+    val artifactStart = dependencyLine.indexOf("--- ")
+    val artifactBase = dependencyLine.substring(artifactStart + 4)
+    val noVersionInBase = artifactBase.indexOf(':') == artifactBase.lastIndexOf(':')
+    val artifact = when {
+        // example: project :lib:base (*)
+        artifactBase.startsWith("project ") -> {
+            artifactBase
+        }
+        // example: com.careem.superapp.lib:base -> 1.26.0 (*)
+        noVersionInBase -> {
+            artifactBase.substringBefore(' ')
+        }
+        else -> {
+            artifactBase.substringBeforeLast(':')
+        }
+    }
+
+    val versionPortion = dependencyLine.substringAfterLast(':')
+    val requestedVersionInfo = when {
+        "project :" in versionPortion -> ""
+        "->" in versionPortion -> versionPortion.substringBefore(" ->")
+        "(*)" in versionPortion -> versionPortion.substringBefore(" (")
+        else -> versionPortion
+    }
+
+    val resolvedVersion = if ("->" in versionPortion) {
+        versionPortion.substringAfter("-> ").substringBefore(" (")
+    } else {
+        requestedVersionInfo
+    }
+
+    return Dependency(
+        group = artifact.substringBefore(':').trim(),
+        name = artifact.substringAfter(':').trim(),
+        resolvedVersion = resolvedVersion,
+        requestedVersion = requestedVersionInfo
+    )
+}
+
+private fun List<String>.safeSublistFrom(index: Int): List<String> {
+    val itemCount = size
+    return if (index < itemCount) {
+        subList(index, itemCount)
+    } else {
+        emptyList()
+    }
+}

--- a/src/main/kotlin/com/careem/gradle/dependencies/treeTldr.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/treeTldr.kt
@@ -17,12 +17,7 @@
 package com.careem.gradle.dependencies
 
 fun tldr(old: String, new: String, collapse: List<String>): String {
-  val oldDependencies = extractDependencies(old)
-  val newDependencies = extractDependencies(new)
-
-  val addedDependencies = newDependencies - oldDependencies
-  val removedDependencies = oldDependencies - newDependencies
-  val (added, removed, upgraded) = partitionDifferences(removedDependencies, addedDependencies)
+  val (added, removed, upgraded) = dependencyDifferences(old, new)
 
   return buildString {
     writeList("New Dependencies", added)
@@ -30,6 +25,15 @@ fun tldr(old: String, new: String, collapse: List<String>): String {
     writeList("Upgraded Dependencies", collapseDependencies(upgraded, collapse),
       removed.isNotEmpty() || added.isNotEmpty())
   }
+}
+
+fun dependencyDifferences(old: String, new: String): VersionDifferences {
+  val oldDependencies = extractDependencies(old)
+  val newDependencies = extractDependencies(new)
+
+  val addedDependencies = newDependencies - oldDependencies
+  val removedDependencies = oldDependencies - newDependencies
+  return partitionDifferences(removedDependencies, addedDependencies)
 }
 
 private fun extractDependencies(deps: String): Set<VersionedDependency> {
@@ -87,7 +91,9 @@ private fun collapseDependencies(
   }
 }
 
-data class VersionedDependency(val artifact: String, val version: String)
+data class VersionedDependency(val artifact: String, val version: String) {
+  val group by lazy { artifact.substringBefore(':').trim() }
+}
 data class VersionDifferences(
   val additions: List<VersionedDependency>,
   val removals: List<VersionedDependency>,

--- a/src/test/fixtures/local_project_update/expected_side_effects.txt
+++ b/src/test/fixtures/local_project_update/expected_side_effects.txt
@@ -1,0 +1,60 @@
+Changing androidx.activity:activity to 1.5.1, (changed from 1.2.4) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing androidx.annotation:annotation-experimental to 1.3.0, (changed from 1.1.0) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+    com.google.android.material:material (1.6.1)
+
+Changing androidx.appcompat:appcompat to 1.5.1, (changed from 1.4.1) will also change:
+    com.google.android.material:material (1.6.1)
+
+Changing androidx.core:core to 1.9.0, (changed from 1.7.0) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+    com.google.android.material:material (1.6.1)
+
+Changing androidx.core:core-ktx to 1.9.0, (changed from 1.7.0) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing androidx.lifecycle:lifecycle-common to 2.5.1, (changed from 2.4.0) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing androidx.lifecycle:lifecycle-livedata-core to 2.5.1, (changed from 2.3.1) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing androidx.lifecycle:lifecycle-runtime to 2.5.1, (changed from 2.4.0) will also change:
+    androidx.core:core-ktx (1.9.0)
+    androidx.appcompat:appcompat (1.5.1)
+    com.google.android.material:material (1.6.1)
+
+Changing androidx.lifecycle:lifecycle-viewmodel to 2.5.1, (changed from 2.3.1) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing androidx.lifecycle:lifecycle-viewmodel-savedstate to 2.5.1, (changed from 2.3.1) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing androidx.savedstate:savedstate to 1.2.0, (changed from 1.1.0) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing androidx.startup:startup-runtime to 1.1.1, (changed from 1.0.0) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+
+Changing com.squareup.okio:okio to 3.2.0, (changed from 3.0.0) will also change:
+    com.squareup.okhttp3:okhttp (4.10.0)
+
+Changing org.jetbrains.kotlin:kotlin-stdlib to 1.7.10, (changed from 1.6.10) will also change:
+    androidx.appcompat:appcompat (1.5.1)
+    com.squareup.okhttp3:okhttp (4.10.0)
+    com.jakewharton.timber:timber (5.0.1)
+
+Changing org.jetbrains.kotlin:kotlin-stdlib-common to 1.7.10, (changed from 1.6.10) will also change:
+    org.jetbrains.kotlinx:kotlinx-coroutines-core (1.6.4)
+    com.squareup.okio:okio (3.2.0)
+
+Changing org.jetbrains.kotlin:kotlin-stdlib-jdk8 to 1.7.10, (changed from 1.6.10) will also change:
+    org.jetbrains.kotlinx:kotlinx-coroutines-core (1.6.4)
+    org.jetbrains.kotlinx:kotlinx-coroutines-android (1.6.4)
+    com.squareup.okio:okio (3.2.0)
+    com.squareup.okhttp3:okhttp-dnsoverhttps (4.10.0)
+
+Changing org.jetbrains.kotlinx:kotlinx-coroutines-android to 1.6.4, (changed from 1.6.0) will also change:
+    androidx.appcompat:appcompat (1.5.1)

--- a/src/test/fixtures/project_update/expected_side_effects.txt
+++ b/src/test/fixtures/project_update/expected_side_effects.txt
@@ -1,0 +1,64 @@
+Changing androidx.annotation:annotation to 1.3.0, (changed from 1.1.0) will also change:
+    androidx.databinding:viewbinding (7.1.2)
+    androidx.core:core-ktx (1.7.0)
+    androidx.appcompat:appcompat (1.4.1)
+    com.google.android.material:material (1.5.0)
+
+Changing androidx.annotation:annotation-experimental to 1.1.0, (changed from 1.0.0) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+    com.google.android.material:material (1.5.0)
+
+Changing androidx.appcompat:appcompat to 1.4.1, (changed from 1.2.0) will also change:
+    com.google.android.material:material (1.5.0)
+
+Changing androidx.arch.core:core-runtime to 2.1.0, (changed from 2.0.0) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+
+Changing androidx.core:core to 1.7.0, (changed from 1.3.2) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+    com.google.android.material:material (1.5.0)
+
+Changing androidx.customview:customview to 1.1.0, (changed from 1.0.0) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+    com.google.android.material:material (1.5.0)
+
+Changing androidx.drawerlayout:drawerlayout to 1.1.1, (changed from 1.0.0) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+
+Changing androidx.fragment:fragment to 1.3.6, (changed from 1.1.0) will also change:
+    com.google.android.material:material (1.5.0)
+
+Changing androidx.lifecycle:lifecycle-common to 2.4.0, (changed from 2.1.0) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+
+Changing androidx.lifecycle:lifecycle-livedata-core to 2.3.1, (changed from 2.0.0) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+
+Changing androidx.lifecycle:lifecycle-runtime to 2.4.0, (changed from 2.1.0) will also change:
+    androidx.core:core-ktx (1.7.0)
+    androidx.appcompat:appcompat (1.4.1)
+    com.google.android.material:material (1.5.0)
+
+Changing androidx.lifecycle:lifecycle-viewmodel to 2.3.1, (changed from 2.1.0) will also change:
+    androidx.appcompat:appcompat (1.4.1)
+
+Changing com.squareup.okio:okio to 3.0.0, (changed from 2.9.0) will also change:
+    com.squareup.okhttp3:okhttp (4.9.3)
+
+Changing org.jetbrains.kotlin:kotlin-stdlib to 1.6.10, (changed from 1.4.21) will also change:
+    androidx.core:core-ktx (1.7.0)
+    com.squareup.okhttp3:okhttp (4.9.3)
+    com.jakewharton.timber:timber (5.0.1)
+
+Changing org.jetbrains.kotlin:kotlin-stdlib-common to 1.6.10, (changed from 1.4.21) will also change:
+    org.jetbrains.kotlinx:kotlinx-coroutines-core (1.6.0)
+    com.squareup.okio:okio (3.0.0)
+
+Changing org.jetbrains.kotlin:kotlin-stdlib-jdk8 to 1.6.10, (changed from 1.4.10) will also change:
+    org.jetbrains.kotlinx:kotlinx-coroutines-core (1.6.0)
+    org.jetbrains.kotlinx:kotlinx-coroutines-android (1.6.0)
+    com.squareup.okio:okio (3.0.0)
+    com.squareup.okhttp3:okhttp-dnsoverhttps (4.9.3)
+
+Changing org.jetbrains:annotations to 20.1.0, (changed from 16.0.1) will also change:
+    org.jetbrains.kotlin:kotlin-stdlib-jdk8 (1.6.10)

--- a/src/test/kotlin/com/careem/gradle/dependencies/FixturesTest.kt
+++ b/src/test/kotlin/com/careem/gradle/dependencies/FixturesTest.kt
@@ -11,12 +11,21 @@ import java.io.File
 class FixturesTest(private val fixtureDir: File) {
 
   @Test
-  fun run() {
+  fun testTldr() {
     val before = fixtureDir.resolve("before.txt").readText()
     val after = fixtureDir.resolve("after.txt").readText()
     val expected = fixtureDir.resolve("expected.txt").readText()
     val actual = tldr(before, after, emptyList())
     assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  fun testSideEffects() {
+    val before = fixtureDir.resolve("before.txt").readText()
+    val after = fixtureDir.resolve("after.txt").readText()
+    val expected = fixtureDir.resolve("expected_side_effects.txt").readText()
+    val effects = upgradeEffects(before, after, emptyList())
+    assertThat(effects).isEqualTo(expected)
   }
 
   companion object {


### PR DESCRIPTION
This adds a flag, -s, or --side-effects, which shows the effects of
upgraded dependencies (i.e. besides the artifacts causing the upgrades,
this highlights artifacts that are transitively upgraded as a result of
the overall version bump).
