### PR TITLE
Introduce a mismatched dependency version listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,68 @@ $ java -jar build/dependency-diff-tldr.jar old.txt new.txt
 java -jar build/dependency-diff-tldr.jar old.txt new.txt
 ```
 
+## Flags
+
+* `-s, --side-efects` - explicitly call out the side effects of dependency
+upgrades (ex upgrading Firebase here also updates it in ...)
+* `-c, --collapse` - collapse a set of grouped dependencies. For example,
+  passing a collapse of `com.careem.care` would result in collapsing updates
+  of `com.careem.care:dep1` and `com.careem.care:dep2` to just
+  `com.careem.care:*`. This flag is repeatable.
+
+## Other Utilities
+
+### Mismatched Dependency Finder
+
+Sometimes, you have a library (for example, `androidx.appcompat:appcompat`)
+and want to make sure that all updates that transitively use this library are
+on the currently resolved version. This tool helps by listing out updates and
+additions in this change set that use a version of that library that is
+transitively upgraded.
+
+For example, if our main app uses `androidx.appcompat:appcompat:1.6.1`, using
+this command and passing `androidx.appcompat:appcompat` as a `-d` parameter
+would highlight all transitive usages on a version that is not 1.6.1 that
+resolves to 1.6.1.
+
+```bash
+java -cp build/dependency-diff-tldr.jar com.careem.gradle.dependencies.mismatched.MismatchedVersionFinder -d androidx.appcompat:appcompat old.txt new.txt
+```
+
+Would result in output like:
+
+```
+androidx.appcompat:appcompat:1.5.1:
+    com.careem.kodelean:recyclerview-compose is requesting 1.5.1 instead of 1.6.1
+    com.careem.kodelean:recyclerview-viewbinding is requesting 1.5.1 instead of 1.6.1
+    com.careem.kodelean:viewbinding-lifecycle is requesting 1.5.1 instead of 1.6.1
+
+androidx.appcompat:appcompat:1.3.0:
+    com.careem.motcore:feature-dynamic_widget is requesting 1.3.0 instead of 1.6.1
+```
+
+Note that the `-c` flag would help simplify this output, such that running:
+
+```bash
+java -cp build/dependency-diff-tldr.jar com.careem.gradle.dependencies.mismatched.MismatchedVersionFinder -c com.careem.kodelean -d androidx.appcompat:appcompat old.txt new.txt
+```
+
+Would result in output like:
+
+```
+androidx.appcompat:appcompat:1.5.1:
+    com.careem.kodelean:* is requesting 1.5.1 instead of 1.6.1
+
+androidx.appcompat:appcompat:1.3.0:
+    com.careem.motcore:feature-dynamic_widget is requesting 1.3.0 instead of 1.6.1
+```
+
+#### Flags
+
+* `-d, --dependency` - watch a library. This flag is repeatable.
+* `-c, --collapse` - collapse a set of grouped dependencies. This flag is repeatable.
+
+
 ## Disclaimer
 
 This project may contain experimental code and may not be ready for general use. Support and/or new releases may be limited.

--- a/src/main/kotlin/com/careem/gradle/dependencies/common/parser/treeParser.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/common/parser/treeParser.kt
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-package com.careem.gradle.dependencies.parser
+package com.careem.gradle.dependencies.common.parser
 
 data class Dependency(
     val group: String,

--- a/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
@@ -16,8 +16,8 @@
 
 package com.careem.gradle.dependencies
 
-import com.careem.gradle.dependencies.parser.Dependency
-import com.careem.gradle.dependencies.parser.parseDependencyTree
+import com.careem.gradle.dependencies.common.parser.Dependency
+import com.careem.gradle.dependencies.common.parser.parseDependencyTree
 
 fun upgradeEffects(old: String, new: String, collapseKeys: List<String>): String {
     val (_, _, upgrades) = dependencyDifferences(old, new)

--- a/src/main/kotlin/com/careem/gradle/dependencies/main.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/main.kt
@@ -24,10 +24,7 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.path
-import java.nio.charset.Charset
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Path
+import kotlin.io.path.readText
 
 class Tldr : CliktCommand(name = "dependency-diff-tldr") {
   private val sideEffects by option(
@@ -62,8 +59,4 @@ class Tldr : CliktCommand(name = "dependency-diff-tldr") {
 
 fun main(args: Array<String>) {
   Tldr().main(args)
-}
-
-private fun Path.readText(charset: Charset = StandardCharsets.UTF_8): String {
-  return Files.readAllBytes(this).toString(charset)
 }

--- a/src/main/kotlin/com/careem/gradle/dependencies/mismatched/main.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/mismatched/main.kt
@@ -1,0 +1,35 @@
+@file:JvmName("MismatchedVersionFinder")
+package com.careem.gradle.dependencies.mismatched
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.path
+import kotlin.io.path.readText
+
+class MismatchedVersionFinderCommand : CliktCommand() {
+  private val dependencies: List<String> by option(
+    "-d",
+    "--dependency",
+    help = "A set of artifacts to watch dependency mismatches for."
+  ).multiple()
+
+  private val collapse: List<String> by option(
+    "-c",
+    "--collapse",
+    help = "Collapse packages with a matching group under a group.*. Collapsing " +
+        "will only occur if all version numbers match. (ex --collapse com.careem.ridehail --collapse com.careem.now)."
+  ).multiple()
+
+  private val old by argument("old.txt").path(mustExist = true)
+  private val new by argument("new.txt").path(mustExist = true)
+
+  override fun run() {
+    print(mismatchedVersions(old.readText(), new.readText(), dependencies, collapse))
+  }
+}
+
+fun main(args: Array<String>) {
+  MismatchedVersionFinderCommand().main(args)
+}

--- a/src/main/kotlin/com/careem/gradle/dependencies/mismatched/mismatched.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/mismatched/mismatched.kt
@@ -1,0 +1,67 @@
+package com.careem.gradle.dependencies.mismatched
+
+import com.careem.gradle.dependencies.dependencyDifferences
+import com.careem.gradle.dependencies.common.parser.Dependency
+import com.careem.gradle.dependencies.common.parser.parseDependencyTree
+
+fun mismatchedVersions(old: String, new: String, watchedLibraries: List<String>, collapse: List<String>): String {
+  val (additions, _, upgrades) = dependencyDifferences(old, new)
+  val total = additions + upgrades
+  return if (total.isNotEmpty() && watchedLibraries.isNotEmpty()) {
+    val tree = parseDependencyTree(new)
+    val upgradedDependencies = total.mapNotNull { tree.findDependency(it.artifact) }
+    val updatesList = watchedLibraries.map { watchedArtifact ->
+      watchedArtifact to upgradedDependencies.mapNotNull { dep ->
+        val matching = dep.findDependency(watchedArtifact)
+        if (matching != null && matching.requestedVersion != matching.resolvedVersion) {
+          dep to matching
+        } else {
+          null
+        }
+      }
+    }
+
+    buildString {
+      updatesList.forEach { (watchedArtifact, updates) ->
+        if (updates.isNotEmpty()) {
+          val groupedUpdates = updates.groupBy { it.second.requestedVersion }
+            .map { (version, deps) ->
+              val groupedVersionedDependencies = deps.groupBy { it.first.group }
+                .flatMap { (group, deps) ->
+                  if (deps.size > 1 && group in collapse) {
+                    val firstDependency = deps.first()
+                    val groupedDep = firstDependency.first.copy(name = "*")
+                    listOf(groupedDep to firstDependency.second)
+                  } else {
+                    deps
+                  }
+                }
+              version to groupedVersionedDependencies
+            }
+
+          groupedUpdates.forEach { (version, deps) ->
+            appendLine("$watchedArtifact:$version:")
+            deps.forEach { (dep, matching) ->
+              appendLine("    ${dep.artifact} is requesting ${matching.requestedVersion} instead of ${matching.resolvedVersion}")
+            }
+            appendLine()
+          }
+        }
+      }
+    }
+  } else {
+    ""
+  }
+}
+
+private fun List<Dependency>.findDependency(artifactId: String): Dependency? {
+  return firstNotNullOfOrNull { it.findDependency(artifactId) }
+}
+
+private fun Dependency.findDependency(artifactId: String): Dependency? {
+  return if (artifactId == artifact) {
+    this
+  } else {
+    children.firstNotNullOfOrNull { it.findDependency(artifactId) }
+  }
+}

--- a/src/main/rules.txt
+++ b/src/main/rules.txt
@@ -5,3 +5,7 @@
 -keep class com.careem.gradle.dependencies.DependencyTreeTldr {
 	public static void main(java.lang.String[]);
 }
+
+-keep class com.careem.gradle.dependencies.mismatched.MismatchedVersionFinder {
+	public static void main(java.lang.String[]);
+}


### PR DESCRIPTION
Implement a command to list outdated versions for a set of artifacts.
This is useful for knowing if certain libraries are being transitively
bumped, when this is not the ideal situation.
