### PR TITLE
Fix the output of mismatched finder

### DIFF
--- a/src/main/kotlin/com/careem/gradle/dependencies/common/parser/util.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/common/parser/util.kt
@@ -1,0 +1,30 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.careem.gradle.dependencies.common.parser
+
+fun Dependency.filterMatches(lambda: (Dependency) -> Boolean): Dependency? {
+  return if (lambda(this)) {
+    this.copy(children = emptyList())
+  } else {
+    val children = this.children.mapNotNull { it.filterMatches(lambda) }
+    if (children.isNotEmpty()) {
+      this.copy(children = children)
+    } else {
+      null
+    }
+  }
+}

--- a/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
@@ -17,6 +17,7 @@
 package com.careem.gradle.dependencies
 
 import com.careem.gradle.dependencies.common.parser.Dependency
+import com.careem.gradle.dependencies.common.parser.filterMatches
 import com.careem.gradle.dependencies.common.parser.parseDependencyTree
 
 fun upgradeEffects(old: String, new: String, collapseKeys: List<String>): String {
@@ -77,19 +78,6 @@ fun upgradeEffects(old: String, new: String, collapseKeys: List<String>): String
 }
 
 private fun Dependency.matches(target: String) = artifact == target
-
-private fun Dependency.filterMatches(lambda: (Dependency) -> Boolean): Dependency? {
-    return if (lambda(this)) {
-        this.copy(children = emptyList())
-    } else {
-        val children = this.children.mapNotNull { it.filterMatches(lambda) }
-        if (children.isNotEmpty()) {
-            this.copy(children = children)
-        } else {
-            null
-        }
-    }
-}
 
 private fun StringBuilder.writeTree(dependency: Dependency, indent: Int) {
     appendLine()

--- a/src/main/kotlin/com/careem/gradle/dependencies/mismatched/main.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/mismatched/main.kt
@@ -1,3 +1,19 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 @file:JvmName("MismatchedVersionFinder")
 package com.careem.gradle.dependencies.mismatched
 
@@ -12,7 +28,7 @@ class MismatchedVersionFinderCommand : CliktCommand() {
   private val dependencies: List<String> by option(
     "-d",
     "--dependency",
-    help = "A set of artifacts to watch dependency mismatches for."
+    help = "A set of artifacts to watch dependency mismatches for from the added/updated dependencies."
   ).multiple()
 
   private val collapse: List<String> by option(


### PR DESCRIPTION
The output of the mismatched dependency finder was sometimes confusing,
or overall incorrect.
