### PR TITLE
Add a tool for catching illegal dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,32 @@ androidx.appcompat:appcompat:1.3.0:
 * `-d, --dependency` - watch a library. This flag is repeatable.
 * `-c, --collapse` - collapse a set of grouped dependencies. This flag is repeatable.
 
+### Illegal Dependencies Finder
+
+There are often times when a certain specific version of a dependency should not be used,
+due for example to it being broken or having some sort of issues. This tool checks to see
+if any of a set of illegal dependencies are used, and flags their usages.
+
+```bash
+java -cp build/dependency-diff-tldr.jar com.careem.gradle.dependencies.denylist.DenyListEnforcer \
+    dependencies.txt \
+    -d com.careem.superapp.test:example:1.62.0 \
+    -d com.careem.superapp.test:another:1.62.0
+```
+
+Would result in output like:
+
+```
+Illegal dependency: com.careem.superapp.test:example:1.62.0:
+    com.careem.superapp.test:example (1.62.0)
+
+    project:lib:base (base)
+        project:lib:analytics-impl (analytics-impl)
+            com.careem.superapp.test:example (1.62.0)
+```
+
+Alternatively, you can pass in `-df <illegal.txt>`, where `illegal.txt` would contain
+one line per illegal dependency.
 
 ## Disclaimer
 

--- a/src/main/kotlin/com/careem/gradle/dependencies/common/util.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/common/util.kt
@@ -1,0 +1,42 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.careem.gradle.dependencies.common
+
+import com.careem.gradle.dependencies.common.parser.Dependency
+
+internal fun Dependency.filterMatches(lambda: (Dependency) -> Boolean): Dependency? {
+  return if (lambda(this)) {
+    this.copy(children = emptyList())
+  } else {
+    val children = this.children.mapNotNull { it.filterMatches(lambda) }
+    if (children.isNotEmpty()) {
+      this.copy(children = children)
+    } else {
+      null
+    }
+  }
+}
+
+internal fun StringBuilder.writeTree(dependency: Dependency, indent: Int) {
+  appendLine()
+  append(" ".repeat(indent * 4))
+  append(dependency.artifact)
+  append(" (")
+  append(dependency.resolvedVersion)
+  append(")")
+  dependency.children.forEach { writeTree(it, indent + 1) }
+}

--- a/src/main/kotlin/com/careem/gradle/dependencies/denylist/denylist.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/denylist/denylist.kt
@@ -1,0 +1,53 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.careem.gradle.dependencies.denylist
+
+import com.careem.gradle.dependencies.common.filterMatches
+import com.careem.gradle.dependencies.common.parser.Dependency
+import com.careem.gradle.dependencies.common.parser.parseDependencyTree
+
+fun illegalDependencies(dependencies: String, illegalDependencies: List<String>): Map<Dependency, List<Dependency>> {
+  return if (illegalDependencies.isEmpty()) {
+    emptyMap()
+  } else {
+    val tree = parseDependencyTree(dependencies)
+    val denyListDependencies = illegalDependencies.map { it.asDependency() }
+    denyListDependencies
+      .map { illegal ->
+        val result = tree.mapNotNull { treeDependency ->
+          treeDependency.filterMatches { it.matches(illegal) }
+        }
+        illegal to result
+      }
+      .filter { (_, matches) -> matches.isNotEmpty() }
+      .associateBy(
+        keySelector = { it.first },
+        valueTransform = { it.second }
+      )
+  }
+}
+
+internal fun Dependency.matches(target: Dependency) =
+  artifact == target.artifact && requestedVersion == target.resolvedVersion
+
+private fun String.asDependency(): Dependency {
+  val pieces = this.split(":")
+  val group = pieces[0]
+  val artifact = pieces[1]
+  val version = pieces[2]
+  return Dependency(group, artifact, version, version)
+}

--- a/src/main/kotlin/com/careem/gradle/dependencies/denylist/main.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/denylist/main.kt
@@ -1,0 +1,75 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+@file:JvmName("DenyListEnforcer")
+package com.careem.gradle.dependencies.denylist
+
+import com.careem.gradle.dependencies.common.parser.Dependency
+import com.careem.gradle.dependencies.common.writeTree
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
+import com.github.ajalt.clikt.parameters.groups.required
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.file
+import com.github.ajalt.clikt.parameters.types.path
+import kotlin.io.path.readText
+
+/**
+ * Finds usages of a set of absolutely unacceptable, intolerable,
+ * and illicit dependencies.
+ */
+class DenyListEnforcerCommand : CliktCommand() {
+  private val unacceptableDependencies by mutuallyExclusiveOptions(
+    option(
+      "-d",
+      "--dependency",
+      help = "A set of artifacts to ensure aren't used - ex com.dep:a:1.2.3,com.dep:b:1.3.4"
+    ).multiple(),
+
+    option("-df", help = "File containing illegal dependencies")
+      .file(mustExist = true)
+      .convert { it.readLines() }
+  ).required()
+
+  private val deps by argument("deps.txt").path(mustExist = true)
+
+  override fun run() {
+    val illegal = illegalDependencies(deps.readText(), unacceptableDependencies)
+    if (illegal.isNotEmpty()) {
+      val result = buildString {
+        illegal.forEach { (dependency, usages) ->
+          append("Illegal dependency: ${dependency.fullName()}:")
+          usages.forEach {
+            writeTree(it, 1)
+            appendLine()
+          }
+        }
+      }
+      print(result)
+    }
+  }
+
+  private fun Dependency.fullName(): String {
+    return "$artifact:$requestedVersion"
+  }
+}
+
+fun main(args: Array<String>) {
+  DenyListEnforcerCommand().main(args)
+}

--- a/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/effectFinder.kt
@@ -16,8 +16,10 @@
 
 package com.careem.gradle.dependencies
 
+import com.careem.gradle.dependencies.common.filterMatches
 import com.careem.gradle.dependencies.common.parser.Dependency
 import com.careem.gradle.dependencies.common.parser.parseDependencyTree
+import com.careem.gradle.dependencies.common.writeTree
 
 fun upgradeEffects(old: String, new: String, collapseKeys: List<String>): String {
     val (_, _, upgrades) = dependencyDifferences(old, new)
@@ -76,27 +78,4 @@ fun upgradeEffects(old: String, new: String, collapseKeys: List<String>): String
     }
 }
 
-private fun Dependency.matches(target: String) = artifact == target
-
-private fun Dependency.filterMatches(lambda: (Dependency) -> Boolean): Dependency? {
-    return if (lambda(this)) {
-        this.copy(children = emptyList())
-    } else {
-        val children = this.children.mapNotNull { it.filterMatches(lambda) }
-        if (children.isNotEmpty()) {
-            this.copy(children = children)
-        } else {
-            null
-        }
-    }
-}
-
-private fun StringBuilder.writeTree(dependency: Dependency, indent: Int) {
-    appendLine()
-    append(" ".repeat(indent * 4))
-    append(dependency.artifact)
-    append(" (")
-    append(dependency.resolvedVersion)
-    append(")")
-    dependency.children.forEach { writeTree(it, indent + 1) }
-}
+internal fun Dependency.matches(target: String) = artifact == target

--- a/src/main/kotlin/com/careem/gradle/dependencies/mismatched/main.kt
+++ b/src/main/kotlin/com/careem/gradle/dependencies/mismatched/main.kt
@@ -1,3 +1,19 @@
+/*
+* Copyright Careem, an Uber Technologies Inc. company
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 @file:JvmName("MismatchedVersionFinder")
 package com.careem.gradle.dependencies.mismatched
 

--- a/src/main/rules.txt
+++ b/src/main/rules.txt
@@ -9,3 +9,7 @@
 -keep class com.careem.gradle.dependencies.mismatched.MismatchedVersionFinder {
 	public static void main(java.lang.String[]);
 }
+
+-keep class com.careem.gradle.dependencies.denylist.DenyListEnforcer {
+	public static void main(java.lang.String[]);
+}


### PR DESCRIPTION
Sometimes, there is a list of illegal, illicit, broken, or otherwise
simply unacceptable dependencies. This script helps pinpoint usages of
these within the dependency tree.